### PR TITLE
Add desktop file support and the ability to download locale specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ by executing: ```ghostery``` (or as a fallback: ```~/.local/bin/ghostery```).
 If want to undo the changes made by the installer, you can execute:
 
 ```
-rm -rf ~/bin/ghostery ~/.local/bin/ghostery ~/.local/opt/ghostery/Ghostery
+rm -rf ~/bin/ghostery ~/.local/bin/ghostery ~/.local/opt/ghostery/Ghostery ~/.local/share/applications/ghostery-dawn.desktop
 ```
 
 ### Troubleshooting <a name="troubleshooting"></a>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Now running ```ghostery``` will have the same effect as running
 ### Generic Install Script <a name="installscript"></a>
 
 In this repository, you will find `install-ghostery.sh`, which automates
-the steps to download the latest binary build and installs it for your
+the steps to download the latest binary build and install it for your
 local user (in `~/.local/opt` and `~/.local/bin`).
 
 Once the installation finishes, you should be able to start the browser

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ In this repository, you will find `install-ghostery.sh`, which automates
 the steps to download the latest binary build and install it for your
 local user (in `~/.local/opt` and `~/.local/bin`).
 
+By default, this script will download and install the english version of the
+browser. But you can pass a lang code as argument to download another version
+of it (currently, only fr, de and en-US versions are available):
+`./install-ghostery.sh de`
+
 Once the installation finishes, you should be able to start the browser
 by executing: ```ghostery``` (or as a fallback: ```~/.local/bin/ghostery```).
 

--- a/data/ghostery-dawn.desktop
+++ b/data/ghostery-dawn.desktop
@@ -1,0 +1,36 @@
+[Desktop Entry]
+Version=1.0
+Name=Ghostery Dawn
+GenericName=Web Browser
+GenericName[de]=Webbrowser
+GenericName[fr]=Navigateur Web
+Comment=Browse the World Wide Web
+Comment[de]=Im Internet surfen
+Comment[fr]=Naviguer sur le Web
+Keywords=Internet;WWW;Browser;Web;Explorer
+Keywords[de]=Internet;WWW;Browser;Web;Explorer;Webseite;Site;surfen;online;browsen
+Keywords[fr]=Internet;WWW;Browser;Web;Explorer;Fureteur;Surfer;Navigateur
+Exec=[TARGET]/Ghostery %u
+Icon=[TARGET]/browser/chrome/icons/default/default64.png
+Terminal=false
+X-MultipleArgs=false
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
+StartupNotify=true
+StartupWMClass=ghostery
+Categories=Network;WebBrowser;
+Actions=new-window;new-private-window;
+
+[Desktop Action new-window]
+Name=New Window
+Name[de]=Neues Fenster
+Name[en_US]=New Window
+Name[fr]=Nouvelle fenêtre
+Exec=[TARGET]/Ghostery --new-window %u
+
+[Desktop Action new-private-window]
+Name=New Private Window
+Name[de]=Neues privates Fenster
+Name[en_US]=New Private Window
+Name[fr]=Nouvelle fenêtre de navigation privée
+Exec=[TARGET]/Ghostery --private-window %u

--- a/install-ghostery.sh
+++ b/install-ghostery.sh
@@ -46,6 +46,8 @@ TARGET_BASE="$HOME/.local/opt/ghostery"
 TARGET="$TARGET_BASE/Ghostery"
 WRAPPER_SCRIPT_PREFIX="$HOME/.local/bin"
 WRAPPER_SCRIPT="$WRAPPER_SCRIPT_PREFIX/ghostery"
+APPLICATION_PREFIX="$HOME/.local/share/applications"
+APPLICATION_LAUNCHER="$APPLICATION_PREFIX/ghostery-dawn.desktop"
 
 mkdir -p "$TARGET_BASE"
 if [[ -e $TARGET ]]; then
@@ -74,6 +76,20 @@ exec ./Ghostery "\$@"
 EOF
 chmod a+x "$WRAPPER_SCRIPT"
 
+GRAPHICAL_MENU=n
+if type -p update-desktop-database > /dev/null; then
+    echo "Creating application launcher"
+    mkdir -p "$APPLICATION_PREFIX"
+    # FIXME: once merged in master, the following line must be replaced by a
+    # download from github repo, as the main usage of this script is to be run
+    # outside this repository. Or maybe better, should be embed in the browser
+    # tarball itself?
+    cp data/ghostery-dawn.desktop "$APPLICATION_LAUNCHER"
+    sed -i "s|\[TARGET\]|$TARGET|" "$APPLICATION_LAUNCHER"
+    update-desktop-database "$APPLICATION_PREFIX"
+    GRAPHICAL_MENU=y
+fi
+
 # Some distributions have ~/bin in the path but not ~/.local/bin.
 if ! type -p ghostery > /dev/null; then
   if [[ -e $HOME/bin/ ]]; then
@@ -84,8 +100,16 @@ if ! type -p ghostery > /dev/null; then
 fi
 
 echo "Ghostery dawn has been successfully extracted to $TARGET."
-echo
-echo "You can start it by running the following command:"
+if [ "$GRAPHICAL_MENU" = y ]; then
+    echo
+    echo "You should find it in your application menu and click Ghosty icon to start it."
+    echo
+    echo -n "You can also start it "
+else
+    echo
+    echo -n "You can start it "
+fi
+echo "by running the following command:"
 if type -p ghostery > /dev/null; then
     echo "ghostery"
 else

--- a/install-ghostery.sh
+++ b/install-ghostery.sh
@@ -29,9 +29,9 @@ if [[ $(whoami) = root ]]; then
 fi
 
 # Locations: application ~/.local/opt/ghostery/Ghostery and ~/.local/bin/ghostery
-TARGET_BASE=~/.local/opt/ghostery
+TARGET_BASE="$HOME/.local/opt/ghostery"
 TARGET="$TARGET_BASE/Ghostery"
-WRAPPER_SCRIPT_PREFIX=~/.local/bin
+WRAPPER_SCRIPT_PREFIX="$HOME/.local/bin"
 WRAPPER_SCRIPT="$WRAPPER_SCRIPT_PREFIX/ghostery"
 
 mkdir -p "$TARGET_BASE"
@@ -63,10 +63,10 @@ chmod a+x "$WRAPPER_SCRIPT"
 
 # Some distributions have ~/bin in the path but not ~/.local/bin.
 if ! type -p ghostery > /dev/null; then
-  if [[ -e ~/bin/ ]]; then
-      echo "~/.local/bin is not in the path, but it detected that ~/bin is."
-      echo "Creating a symlink from ~/bin/ghostery to $WRAPPER_SCRIPT."
-      (cd ~/bin && ln -s "$WRAPPER_SCRIPT" .)
+  if [[ -e $HOME/bin/ ]]; then
+      echo "$HOME/.local/bin is not in the path, but it detected that $HOME/bin is."
+      echo "Creating a symlink from $HOME/bin/ghostery to $WRAPPER_SCRIPT."
+      (cd $HOME/bin && ln -s "$WRAPPER_SCRIPT" .)
   fi
 fi
 
@@ -81,5 +81,5 @@ else
     echo "Hint: consider adding ~/.local/bin/ghostery in your PATH."
     echo "For example, by adding this to your ~/.bashrc file:"
     echo
-    echo 'export PATH="${PATH:+${PATH}:}~/.local/bin"'
+    echo 'export PATH="${PATH:+${PATH}:}$HOME/.local/bin"'
 fi

--- a/install-ghostery.sh
+++ b/install-ghostery.sh
@@ -7,7 +7,7 @@
 # Before running it, it is recommended to backup the profiles
 # in "~/.ghostery browser".
 #
-# Note: 
+# Note:
 #
 set -Eeuo pipefail
 
@@ -78,7 +78,7 @@ if type -p ghostery > /dev/null; then
 else
     echo "$WRAPPER_SCRIPT"
     echo
-    echo "Hint: consider adding ~/.local/bin/ghostery ot your PATH."
+    echo "Hint: consider adding ~/.local/bin/ghostery in your PATH."
     echo "For example, by adding this to your ~/.bashrc file:"
     echo
     echo 'export PATH="${PATH:+${PATH}:}~/.local/bin"'

--- a/install-ghostery.sh
+++ b/install-ghostery.sh
@@ -28,9 +28,9 @@ RELEASE_URL="https://get.ghosterybrowser.com/download/linux/$LANG"
 
 # either wget or curl:
 if type -p wget > /dev/null; then
-    DOWNLOAD_CMD="wget --no-verbose --output-document -"
+    DOWNLOAD_CMD="wget --no-verbose --show-progress --output-document -"
 elif type -p curl > /dev/null; then
-    DOWNLOAD_CMD="curl -L"
+    DOWNLOAD_CMD="curl -L --progress-bar"
 else
     echo "ERROR: did not find a tool to download the release (install wget or curl)"
     exit 1

--- a/install-ghostery.sh
+++ b/install-ghostery.sh
@@ -11,7 +11,20 @@
 #
 set -Eeuo pipefail
 
-RELEASE_URL="https://get.ghosterybrowser.com/download/linux/en-US"
+LANG="${1:-en-US}"
+case "$LANG" in
+    fr|FR|fr-FR|fr_FR)
+        LANG=fr
+        ;;
+    de|DE|de-DE|de_DE)
+        LANG=de
+        ;;
+    *)
+        LANG=en-US
+        ;;
+esac
+
+RELEASE_URL="https://get.ghosterybrowser.com/download/linux/$LANG"
 
 # either wget or curl:
 if type -p wget > /dev/null; then


### PR DESCRIPTION
The install-ghostery.sh` script now allow an optional argument to download a locale specific (fr, de or en_us) version of the browser.

It also add the support for a `.desktop` file, well known way of adding launcher in most distribution application launcher (this part has to be discussed, whether it’s up to this repository to host this desktop file, or the `user-agent-desktop` one).

Plus some little fixes.