### PR TITLE
Flatpak package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+flatpak/.flatpak-builder/
+flatpak/build-dir/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flatpak/shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/data/ghostery-dawn.desktop
+++ b/data/ghostery-dawn.desktop
@@ -17,7 +17,7 @@ X-MultipleArgs=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;application/x-xpinstall;application/pdf;application/json;
 StartupNotify=true
-StartupWMClass=ghostery
+StartupWMClass=Ghostery
 Categories=Network;WebBrowser;
 Actions=new-window;new-private-window;
 

--- a/data/policies.json
+++ b/data/policies.json
@@ -1,0 +1,6 @@
+{
+  "_origin_": "https://github.com/mozilla/policy-templates",
+  "policies": {
+    "DisableAppUpdate": true
+  }
+}

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -1,0 +1,22 @@
+.PHONY: build clean cleanall install run uninstall
+
+all: build
+
+build: clean
+	flatpak --user --noninteractive install org.freedesktop.Sdk//22.08
+	flatpak-builder build-dir com.ghostery.dawn.yml
+
+install:
+	flatpak-builder --user --install --force-clean build-dir com.ghostery.dawn.yml
+
+run:
+	flatpak --user run com.ghostery.dawn
+
+uninstall:
+	flatpak --user --noninteractive uninstall com.ghostery.dawn || true
+
+clean:
+	rm -rf build-dir
+
+cleanall: clean
+	rm -rf .flatpak-builder

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,21 @@
+# Flatpak packaging
+
+Current manifest is largely inspired by the one from [Librewolf community](https://gitlab.com/librewolf-community/browser/flatpak/)
+
+To build it, you can use the provided `Makefile`:
+
+- `make` or `make build` to create a local flatpak package
+- `make install` to install a previously created local flatpak package
+- `make uninstall` to uninstall the flatpak previously installed
+- `flatpak --user run com.ghostery.dawn` or `make run` to launch a previously
+  installed version (you should also be able to just click on the Ghostery
+  icon in your distribution app menu).
+- `make clean` to just remove the build directory (necessary to make a new
+  build, but automatically run by the `build` target)
+- `make cleanall` to remove everything (build directory, flatpak builder cache
+  directory and uninstall any installed ghostery flatpak).
+
+To prepare the manifest file for a new release, you can use the provided ruby
+script:
+
+    ruby upgrade.rb 2022-11-29 2022.8.1

--- a/flatpak/com.ghostery.dawn.appdata.xml
+++ b/flatpak/com.ghostery.dawn.appdata.xml
@@ -26,7 +26,7 @@
     </ul>
   </description>
   <releases>
-    <release version="2023.1" date="2023-03-03"/>
+    <release version="2023.6" date="2023-07-13"/>
   </releases>
   <keywords>
     <keyword>ghostery</keyword>

--- a/flatpak/com.ghostery.dawn.appdata.xml
+++ b/flatpak/com.ghostery.dawn.appdata.xml
@@ -26,7 +26,7 @@
     </ul>
   </description>
   <releases>
-    <release version="2022.8" date="2022-09-06"/>
+    <release version="2022.8.1" date="2022-11-29"/>
   </releases>
   <keywords>
     <keyword>ghostery</keyword>

--- a/flatpak/com.ghostery.dawn.appdata.xml
+++ b/flatpak/com.ghostery.dawn.appdata.xml
@@ -26,7 +26,7 @@
     </ul>
   </description>
   <releases>
-    <release version="2022.8.1" date="2022-11-29"/>
+    <release version="2022.8.2" date="2022-12-12"/>
   </releases>
   <keywords>
     <keyword>ghostery</keyword>

--- a/flatpak/com.ghostery.dawn.appdata.xml
+++ b/flatpak/com.ghostery.dawn.appdata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.ghostery.dawn</id>
+  <launchable type="desktop-id">com.ghostery.dawn.desktop</launchable>
+  <name>Ghostery Dawn</name>
+  <developer_name>Ghostery GmbH.</developer_name>
+  <summary>Ghostery Private Browser</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="2364" height="1178">https://www.ghostery.com/assets/ghostery-dawn-compact-e9620f014c3e4ada19cd61a66c2b9d6f52ca261adeb7dccc4792e42d9e336191.png</image>
+    </screenshot>
+  </screenshots>
+  <description>
+    <p>Take Back Your Online Privacy with Ghostery.</p>
+    <ul>
+      <li><strong>Smarter Ad Blocking</strong>
+      Smart-Browsing automatically optimizes page performance as your browse.</li>
+      <li><strong>Faster Page Loads</strong>
+      Ghostery Blocks trackers to declutter webpages and speed up page loads.</li>
+      <li><strong>100% Open-Source</strong>
+      In our commitment to full transparency Ghostery is open source!</li>
+      <li><strong>Stop Trackers in Their Tracks</strong>
+      Anti-tracking anonymizes your data to further protect your privacy.</li>
+    </ul>
+  </description>
+  <releases>
+    <release version="2022.8" date="2022-09-06"/>
+  </releases>
+  <keywords>
+    <keyword>ghostery</keyword>
+    <keyword>internet</keyword>
+    <keyword>web</keyword>
+  </keywords>
+  <url type="homepage">https://ghostery.com/</url>
+  <url type="bugtracker">https://github.com/ghostery/ghostery-browser-linux-support/issues</url>
+  <provides>
+    <id>com.ghostery.dawn</id>
+  </provides>
+  <content_rating type="oars-1.1" />
+</component>

--- a/flatpak/com.ghostery.dawn.appdata.xml
+++ b/flatpak/com.ghostery.dawn.appdata.xml
@@ -26,7 +26,7 @@
     </ul>
   </description>
   <releases>
-    <release version="2022.8.2" date="2022-12-12"/>
+    <release version="2023.1" date="2023-03-03"/>
   </releases>
   <keywords>
     <keyword>ghostery</keyword>

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -1,0 +1,104 @@
+---
+app-id: com.ghostery.dawn
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    version: '22.08'
+    add-ld-path: "."
+command: ghostery
+finish-args:
+- "--share=ipc"
+- "--share=network"
+- "--socket=wayland"
+- "--socket=fallback-x11"
+- "--socket=pcsc"
+- "--socket=pulseaudio"
+- "--socket=cups"
+- "--env=GTK_PATH=/app/lib/gtkmodules"
+- "--persist=.ghostery browser"
+- "--filesystem=xdg-download:rw"
+- "--filesystem=xdg-run/pipewire-0"
+- "--device=dri"
+- "--talk-name=org.freedesktop.FileManager1"
+- "--system-talk-name=org.freedesktop.NetworkManager"
+- "--talk-name=org.a11y.Bus"
+- "--talk-name=org.gnome.SessionManager"
+- "--talk-name=org.freedesktop.ScreenSaver"
+- "--talk-name=org.gtk.vfs.*"
+- "--talk-name=org.freedesktop.Notifications"
+- "--env=MOZ_ENABLE_WAYLAND=1"
+- "--env=MOZ_USE_XINPUT2=1"
+- "--own-name=com.ghostery.dawn.*"
+- "--own-name=org.mpris.MediaPlayer2.firefox.*"
+- "--share=network"
+modules:
+- shared-modules/dbus-glib/dbus-glib.json
+- name: ghostery
+  buildsystem: simple
+  build-commands:
+  - mkdir -p /app/lib
+  - mv ghostery_app/Ghostery /app/lib/ghostery
+  - install -D -m644 /app/lib/ghostery/browser/chrome/icons/default/default128.png
+    /app/share/icons/hicolor/128x128/apps/com.ghostery.dawn.png
+  - install -D -m644 /app/lib/ghostery/browser/chrome/icons/default/default128.png
+    /app/usr/share/icons/hicolor/128x128/apps/com.ghostery.dawn.png
+  - sed -i 's|\[TARGET\]/Ghostery|ghostery|' com.ghostery.dawn.desktop
+  - sed -i 's|^Icon=.*$|Icon=com.ghostery.dawn|' com.ghostery.dawn.desktop
+  - install -D -m644 com.ghostery.dawn.desktop -t /app/share/applications
+  - install -D -m644 com.ghostery.dawn.appdata.xml -t /app/share/metainfo
+  - install -D -m755 ghostery.sh /app/bin/ghostery
+  - install -d /app/lib/ffmpeg
+  sources:
+  - type: archive
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-09-06/Ghostery-2022.8.en-US.linux.tar.gz
+    sha256: 187ceed6fda13475d1f91a814143400c9e6cbbfdd15933a05847cea2e51b6237
+    dest: ghostery_app
+    strip-components: 0
+    only-arches:
+    - x86_64
+  - type: file
+    path: "../data/ghostery-dawn.desktop"
+    dest-filename: com.ghostery.dawn.desktop
+  - type: file
+    path: ghostery.sh
+  - type: file
+    path: com.ghostery.dawn.appdata.xml
+- name: gtk-cups-backend
+  buildsystem: meson
+  make-args:
+  - modules/printbackends/libprintbackend-cups.so
+  no-make-install: true
+  post-install:
+  - install -Dm 755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
+  sources:
+  - type: archive
+    url: https://download.gnome.org/core/41/41.0/sources/gtk%2B-3.24.30.tar.xz
+    sha256: ba75bfff320ad1f4cfbee92ba813ec336322cc3c660d406aad014b07087a3ba9
+  - type: patch
+    path: gtk3-werror.patch
+- name: gtk-settings
+  buildsystem: simple
+  build-commands:
+  - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
+  sources:
+  - type: file
+    path: gtk-settings.ini
+- name: libnotify
+  buildsystem: meson
+  config-opts:
+  - "-Dtests=false"
+  - "-Dintrospection=disabled"
+  - "-Dman=false"
+  - "-Dgtk_doc=false"
+  - "-Ddocbook_docs=disabled"
+  sources:
+  - sha256: d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557
+    type: archive
+    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.1.tar.xz
+    x-checker-data:
+      project-id: 13149
+      type: anitya
+      url-template: https://download.gnome.org/sources/libnotify/$major.$minor/libnotify-$version.tar.xz

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -54,8 +54,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-11-29/Ghostery-2022.8.1.en-US.linux.tar.gz
-    sha256: 2dc8ac2d4e0824a9ef8f3c82726a3fcfc4e660d1471e2f9fcef047fb5dd2f698
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-12-12/Ghostery-2022.8.2.en-US.linux.tar.gz
+    sha256: dab32f80be4a50b475810bfabaf524c28f79a60703e72db2337180dda5167ca1
     dest: ghostery_app
     strip-components: 0
     only-arches:

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -41,6 +41,7 @@ modules:
   build-commands:
   - mkdir -p /app/lib
   - mv ghostery_app/Ghostery /app/lib/ghostery
+  - install -D -m644 policies.json -t /app/lib/ghostery/distribution
   - install -D -m644 /app/lib/ghostery/browser/chrome/icons/default/default128.png
     /app/share/icons/hicolor/128x128/apps/com.ghostery.dawn.png
   - install -D -m644 /app/lib/ghostery/browser/chrome/icons/default/default128.png
@@ -62,6 +63,8 @@ modules:
   - type: file
     path: "../data/ghostery-dawn.desktop"
     dest-filename: com.ghostery.dawn.desktop
+  - type: file
+    path: "../data/policies.json"
   - type: file
     path: ghostery.sh
   - type: file

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -34,7 +34,7 @@ finish-args:
 - "--own-name=com.ghostery.dawn.*"
 - "--own-name=org.mpris.MediaPlayer2.firefox.*"
 modules:
-- shared-modules/dbus-glib/dbus-glib.json
+- shared-modules/dbus-glib/dbus-glib-0.110.json
 - name: ghostery
   buildsystem: simple
   build-commands:
@@ -53,8 +53,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2023-03-03/Ghostery-2023.1.en-US.linux.tar.gz
-    sha256: 02cae41858166f46a18f0a5220550d6ad0405854caecf71f193afada50ff321f
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2023-07-13/Ghostery-2023.6.en-US.linux.tar.gz
+    sha256: 192ad469558c2bfabd883fc4a851a74325e2af36c87adce36624787cefd6f65d
     dest: ghostery_app
     strip-components: 0
     only-arches:

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -54,8 +54,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-09-06/Ghostery-2022.8.en-US.linux.tar.gz
-    sha256: 187ceed6fda13475d1f91a814143400c9e6cbbfdd15933a05847cea2e51b6237
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-11-29/Ghostery-2022.8.1.en-US.linux.tar.gz
+    sha256: 2dc8ac2d4e0824a9ef8f3c82726a3fcfc4e660d1471e2f9fcef047fb5dd2f698
     dest: ghostery_app
     strip-components: 0
     only-arches:

--- a/flatpak/com.ghostery.dawn.yml
+++ b/flatpak/com.ghostery.dawn.yml
@@ -33,7 +33,6 @@ finish-args:
 - "--env=MOZ_USE_XINPUT2=1"
 - "--own-name=com.ghostery.dawn.*"
 - "--own-name=org.mpris.MediaPlayer2.firefox.*"
-- "--share=network"
 modules:
 - shared-modules/dbus-glib/dbus-glib.json
 - name: ghostery
@@ -54,8 +53,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2022-12-12/Ghostery-2022.8.2.en-US.linux.tar.gz
-    sha256: dab32f80be4a50b475810bfabaf524c28f79a60703e72db2337180dda5167ca1
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2023-03-03/Ghostery-2023.1.en-US.linux.tar.gz
+    sha256: 02cae41858166f46a18f0a5220550d6ad0405854caecf71f193afada50ff321f
     dest: ghostery_app
     strip-components: 0
     only-arches:
@@ -98,9 +97,9 @@ modules:
   - "-Dgtk_doc=false"
   - "-Ddocbook_docs=disabled"
   sources:
-  - sha256: d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557
+  - sha256: c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616
     type: archive
-    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.1.tar.xz
+    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz
     x-checker-data:
       project-id: 13149
       type: anitya

--- a/flatpak/ghostery.sh
+++ b/flatpak/ghostery.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export TMPDIR=$XDG_CACHE_HOME/tmp
+exec /app/lib/ghostery/Ghostery "$@"

--- a/flatpak/gtk-settings.ini
+++ b/flatpak/gtk-settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-print-backends=file,cups

--- a/flatpak/gtk3-werror.patch
+++ b/flatpak/gtk3-werror.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index cbd820da44..0438f6cc7d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -309,7 +309,6 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
+     '-Werror=sequence-point',
+     '-Werror=return-type',
+     '-Werror=trigraphs',
+-    '-Werror=array-bounds',
+     '-Werror=write-strings',
+     '-Werror=address',
+     '-Werror=int-to-pointer-cast',

--- a/flatpak/upgrade.rb
+++ b/flatpak/upgrade.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'fileutils'
+
+unless ARGV.length > 1
+  puts <<~USAGE
+    usage: ruby upgrade.rb RELEASE_DATE RELEASE_VERSION [LANG]
+
+    RELEASE_DATE and RELEASE_VERSION are respectivelly the git tag of a
+    release and its "commercial" name.
+
+    Example:
+
+        ruby upgrade.rb 2022-09-06 2022.8
+
+        ruby upgrade.rb 2022-09-06 2022.8 de
+  USAGE
+  exit 1
+end
+
+release_date = ARGV[0]
+release_version = ARGV[1]
+release_lang = ARGV[2] || 'en-US'
+release_tarball = "Ghostery-#{release_version}.#{release_lang}.linux.tar.gz"
+release_url = "https://github.com/ghostery/user-agent-desktop/releases/download/#{release_date}/#{release_tarball}"
+
+# Download required version:
+system 'curl', '-LO', release_url unless File.exist? release_tarball
+
+release_hash = `sha256sum #{release_tarball}`.split(' ')[0]
+
+data = YAML.load_file('com.ghostery.dawn.yml')
+ghostery_index = data['modules'].index do |mod|
+  mod.is_a?(Hash) && mod['name'] == 'ghostery'
+end
+source_index = data['modules'][ghostery_index]['sources'].index do |source|
+  source.fetch('dest', nil) == 'ghostery_app'
+end
+
+data['modules'][ghostery_index]['sources'][source_index]['url'] = release_url
+data['modules'][ghostery_index]['sources'][source_index]['sha256'] = release_hash
+File.write('com.ghostery.dawn.yml', data.to_yaml)
+
+system 'sed', '-i', "s|<release version=\"[0-9.]*\" date=\"[0-9-]*\"/>|<release version=\"#{release_version}\" date=\"#{release_date}\"/>|", 'com.ghostery.dawn.appdata.xml'
+
+cache_dir = ".flatpak-builder/downloads/#{release_hash}"
+
+FileUtils.mkdir_p cache_dir
+FileUtils.mv release_tarball, cache_dir


### PR DESCRIPTION
Hi,

Here is a working draft of required building blocks to build a flatpak version of ghostery. I take inspiration from [the Librewolf community flatpak repository](https://gitlab.com/librewolf-community/browser/flatpak/). However my proposal differ a little. I've push all the related code in a specific subfolder, in which I’ve` added a little README to explain how to build the beast. I also added a little ruby script (sorry, I’m a ruby guy 😇) to ease the upgrade of the manifest files when a new release is pushed. You can see the result in two later commits in this branch to upgrade from 2022.8 to 2022.8.2 (beta).

It clearly works as expected and I’m already using it on my laptop. But I still consider it as draft as it lack the following things, which should be made by official people:

- [ ] Review the wording of the `com.ghostery.dawn.appdata.xml` file to check that it complies with your brand. That data is what will appear on various app store. I took the screenshot url directly from the official website, but as it contains an asset hash in the URL, I wonder if it will not break once the website is updated. Thus one should really adapth that file to include a more reliable screenshot url
- [ ] Actually check that the reverse-DNS name I took everywhere (`com.ghostery.dawn`), as required by flatpak packaging guideline, complies with your internal naming rule.
- [ ] [Publish](https://docs.flatpak.org/en/latest/publishing.html) it somewhere (flathub?).
- [ ] Finally, I encounter a little annoying detail: when a new release is available (testable by building an out-of-date flatpak), we still got the popup in-browser saying an update is available and that we must download it as it is not possible to self-update (fs is readonly in flatpak). It’s a very confusing popup for end-user as they should only update through flatpak. I did not find a way to mute this popup only in flatpak, when using the generic tarball as upstream source. Maybe a second look can help?

I hope it can help :)